### PR TITLE
Add Go(lang) support

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -51,7 +51,10 @@ var getParser = {
     },
     '.c': function() {
         return require('./parsers/defaultParser');
-    }
+    },
+    '.go': function() {
+        return require('./parsers/defaultParser');
+    },
 };
 
 function isExtSupported(ext) {


### PR DESCRIPTION
`.go` files should be parseable with the `defaultParser` since go uses the same comment conventions as C/C++