### PR TITLE
Created mappings for .handlebars and .css

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -16,6 +16,9 @@ var parsers = {
     '.hbs': function () {
         return require('./parsers/hbsParser');
     },
+    '.handlebars': function () {
+        return require('./parsers/hbsParser');
+    },
     '.twig': function () {
         return require('./parsers/twigParser');
     },
@@ -23,6 +26,9 @@ var parsers = {
         return require('./parsers/defaultParser');
     },
     '.scss': function () {
+        return require('./parsers/defaultParser');
+    },
+    '.css': function () {
         return require('./parsers/defaultParser');
     },
     '.ts': function () {


### PR DESCRIPTION
- The handlebars library [officially supports](https://github.com/wycats/handlebars.js/blob/2c1d509c6cafea145ece5ff9bc8b5c2ca98f9749/lib/index.js#L23) both `.handlebars` and `.hbs` extensions. So mapped the extension to the existing parser for compatability.
- Although most folks use either `.scss` or `.less` these days `.css` is still in use, so mapped it to the default parser.