### PR TITLE
added erb with twig parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ to extract your todos from comments.
 | Coffee-React | `.cjsx`              | Supports `#` comments.             |
 | Coffeescript | `.coffee`            | Supports `#` comments.             |
 | EJS          | `.ejs`               | Supports `<!-- -->` and `<%# %>`   |
+| erb          | `.erb`               | Supports `<!-- -->`                |
 | Erlang       | `.erl`               | Supports `%` comments.             |
 | Go           | `.go`                | Supports `// and /* */` comments.  |
 | HTML         | `.html` `.htm`       | Supports `<!-- -->`                |

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -11,6 +11,7 @@ var parsersDb = {
     '.cs': { parserName: 'defaultParser' },
     '.css': { parserName: 'defaultParser' },
     '.ejs': { parserName: 'ejsParser' },
+    '.erb': { parserName: 'twigParser' },
     '.erl': { parserName: 'erlangParser' },
     '.es': { parserName: 'defaultParser' },
     '.es6': { parserName: 'defaultParser' },


### PR DESCRIPTION
I added the ERB extension using the same parser as HTML since they are basically the same.  Since erb uses the HTML parser I didn't add any tests since they would be redundant.