### PR TITLE
fixed example to include named params

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ var contents = fs.readFileSync('./contents.js', 'utf8');
 var filetype = path.extname('./contents.js');
 // add file for better reporting
 var file = 'contents.js';
-var todos = leasot.parse(ext: filetype,content: contents,fileName: file);
+var todos = leasot.parse({ext: filetype,content: contents,fileName: file});
 
 // -> todos now contains the array of todos/fixme parsed
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ var contents = fs.readFileSync('./contents.js', 'utf8');
 var filetype = path.extname('./contents.js');
 // add file for better reporting
 var file = 'contents.js';
-var todos = leasot.parse(filetype, contents, file);
+var todos = leasot.parse(ext: filetype,content: contents,fileName: file);
 
 // -> todos now contains the array of todos/fixme parsed
 


### PR DESCRIPTION
I added named params to the example since they seem to be required, running the example as it is written in the Readme and I got:

```
[16:30:53] Type: .erb
/<location>/node_modules/leasot/lib/parsers.js:59
        throw new Error('extension ' + ext + ' is not supported.');
        ^

Error: extension undefined is not supported.
```