### PR TITLE
Adding SilverStripe template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ to extract your todos from comments.
 | Ruby         | `.rb`                | Supports `#` comments.             |
 | Sass         | `.sass` `.scss`      | Supports `// and /* */` comments.  |
 | Shell        | `.sh` `.zsh` `.bash` | Supports `#` comments.             |
+| SilverStripe | `.ss`                | Supports `<%-- --%>` comments.     |
 | Stylus       | `.styl`              | Supports `// and /* */` comments.  |
 | Twig         | `.twig`              | Supports `{#  #}` and `<!-- -->`   |
 | Typescript   | `.ts`                | Supports `// and /* */` comments.  |

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -38,6 +38,7 @@ var parsersDb = {
     '.sass': { parserName: 'defaultParser' },
     '.scss': { parserName: 'defaultParser' },
     '.sh': { parserName: 'coffeeParser' },
+    '.ss': { parserName: 'ssParser' },
     '.styl': { parserName: 'defaultParser' },
     '.ts': { parserName: 'defaultParser' },
     '.twig': { parserName: 'twigParser' },

--- a/lib/parsers/ssParser.js
+++ b/lib/parsers/ssParser.js
@@ -1,0 +1,22 @@
+'use strict';
+var commentsUtil = require('../utils/comments');
+
+module.exports = function (params) {
+    params = params || {};
+    var regex = commentsUtil.getRegex(params.customTags);
+    var commentsRegex = new RegExp('<%--' + regex + '--%>', 'mig');
+
+    return function parse(contents, file) {
+        var comments = [];
+
+        contents.split('\n').forEach(function (line, index) {
+            var match = commentsRegex.exec(line);
+            var comment = commentsUtil.prepareComment(match, index + 1, file);
+            if (!comment) {
+                return;
+            }
+            comments.push(comment);
+        });
+        return comments;
+    };
+};

--- a/lib/parsers/ssParser.js
+++ b/lib/parsers/ssParser.js
@@ -4,18 +4,33 @@ var commentsUtil = require('../utils/comments');
 module.exports = function (params) {
     params = params || {};
     var regex = commentsUtil.getRegex(params.customTags);
-    var commentsRegex = new RegExp('<%--' + regex + '--%>', 'mig');
+    var ssCommentRegex = new RegExp('<%--' + regex + '--%>', 'mig');
+    var htmlCommentRegex = new RegExp('<!--' + regex + '-->', 'mig');
 
     return function parse(contents, file) {
         var comments = [];
 
         contents.split('\n').forEach(function (line, index) {
-            var match = commentsRegex.exec(line);
-            var comment = commentsUtil.prepareComment(match, index + 1, file);
-            if (!comment) {
-                return;
+            var ssCommentsMatch = ssCommentRegex.exec(line);
+            var comment;
+            while (ssCommentsMatch) {
+                comment = commentsUtil.prepareComment(ssCommentsMatch, index + 1, file);
+                if (!comment) {
+                    return;
+                }
+                comments.push(comment);
+                ssCommentsMatch = ssCommentRegex.exec(line);
             }
-            comments.push(comment);
+
+            var htmlCommentMatch = htmlCommentRegex.exec(line);
+            while (htmlCommentMatch) {
+                comment = commentsUtil.prepareComment(htmlCommentMatch, index + 1, file);
+                if (!comment) {
+                    break;
+                }
+                comments.push(comment);
+                htmlCommentMatch = htmlCommentRegex.exec(line);
+            }
         });
         return comments;
     };

--- a/tests/fixtures/silverstripe.ss
+++ b/tests/fixtures/silverstripe.ss
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <!-- FIXME: title is incorrect -->
+        <title><% if $Title %>{$Title}<% else %>My Webpage<% end_if %></title>
+        <%-- TODO: add stylesheets and scripts --%>
+        <% include $Meta %>
+    </head>
+    <body>
+    <div>
+        <%-- FIXME: $Condition is not defined --%>
+        <!-- Start loop -->
+        <% loop $Condition %>
+        Loop content
+        <% end_loop %>
+    </div>
+    </body>
+</html>

--- a/tests/parser-spec.js
+++ b/tests/parser-spec.js
@@ -370,6 +370,18 @@ describe('parsing', function () {
             verifyComment(comments[0], 'FIXME', 31, 'we now exit the program');
         });
     });
+    
+    describe('ss', function () {
+        it('handle <%-- --%> and <!-- --> comments', function () {
+            var file = getFixturePath('silverstripe.ss');
+            var comments = getComments(file);
+            should.exist(comments);
+            comments.should.have.length(3);
+            verifyComment(comments[0], 'FIXME', 4, 'title is incorrect');
+            verifyComment(comments[1], 'TODO', 6, 'add stylesheets and scripts');
+            verifyComment(comments[2], 'FIXME', 11, '$Condition is not defined');
+        });
+    });
 
     describe('less', function () {
         it('handles block and inline comment forms', function () {


### PR DESCRIPTION
There is currently no way to parse SilverStripe templates (.ss). This PR adds support for `<%-- --%>`  and <!-- --> comments in these files.