### PR TITLE
Support for associating new ext with parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Associates a bundled parser with a new extension.
 
 The parsers object must be completed in the following format:
 
-```json
+```js
 { 
     '.cls': { 
         parserName: 'defaultParser'

--- a/README.md
+++ b/README.md
@@ -22,41 +22,42 @@ to extract your todos from comments.
 - Spaces are trimmed around comment text.
 - Supported default types are `TODO` and `FIXME` - case insensitive.
 - Additional types can be added (using `tags` in cli and `customTags` in `leasot.parse`)
+- New extensions can be associated with bundled parsers as many languages have overlapping syntax
 
 ## Supported languages:
 
-| Filetype     | Extension            | Notes                              |
-| ------------ | -------------------- | -----------------------------------|
-| C#           | `.cs`                | Supports `// and /* */` comments.  |
-| C++/C        | `.cpp` `.c` `.h`     | Supports `// and /* */` comments.  |
-| CSS          | `.css`               | Supports `/* */` comments.         |
-| Coffee-React | `.cjsx`              | Supports `#` comments.             |
-| Coffeescript | `.coffee`            | Supports `#` comments.             |
-| EJS          | `.ejs`               | Supports `<!-- -->` and `<%# %>`   |
-| erb          | `.erb`               | Supports `<!-- -->`                |
-| Erlang       | `.erl`               | Supports `%` comments.             |
-| Go           | `.go`                | Supports `// and /* */` comments.  |
-| Haml         | `.haml`              | Supports `/ -# <!-- --> and <%# %>`|
-| HTML         | `.html` `.htm`       | Supports `<!-- -->`                |
-| Handlebars   | `.hbs` `.handlebars` | Supports `{{! }}` and `{{!-- --}}` |
-| Haskell      | `.hs`                | Supports `--`                      |
-| Hogan        | `.hgn` `.hogan`      | Supports `{{! }}` and `{{!-- --}}` |
-| Jade         | `.jade`              | Supports `//` and `//-` comments.  |
-| Javascript   | `.js` `.es` `.es6`   | Supports `// and /* */` comments   |
-| Jsx          | `.jsx`               | Supports `// and /* */` comments.  |
-| Less         | `.less`              | Supports `// and /* */` comments.  |
-| Mustache     | `.mustache`          | Supports `{{! }}` and `{{!-- --}}` |
-| Pascal       | `.pas`               | Supports `// and { }` comments.    |
-| PHP          | `.php`               | Supports `// and /* */` comments.  |
-| Perl         | `.pl`, `.pm`         | Supports `#` comments.             |
-| Python       | `.py`                | Supports `"""` and `#` comments.   |
-| Ruby         | `.rb`                | Supports `#` comments.             |
-| Sass         | `.sass` `.scss`      | Supports `// and /* */` comments.  |
-| Shell        | `.sh` `.zsh` `.bash` | Supports `#` comments.             |
-| SilverStripe | `.ss`                | Supports `<%-- --%>` comments.     |
-| Stylus       | `.styl`              | Supports `// and /* */` comments.  |
-| Twig         | `.twig`              | Supports `{#  #}` and `<!-- -->`   |
-| Typescript   | `.ts`                | Supports `// and /* */` comments.  |
+| Filetype     | Extension            | Notes                              | Parser Name         |
+| ------------ | -------------------- | -----------------------------------| ------------------- |
+| C#           | `.cs`                | Supports `// and /* */` comments.  | defaultParser       |
+| C++/C        | `.cpp` `.c` `.h`     | Supports `// and /* */` comments.  | defaultParser       |
+| CSS          | `.css`               | Supports `/* */` comments.         | defaultParser       |
+| Coffee-React | `.cjsx`              | Supports `#` comments.             | coffeeParser        |
+| Coffeescript | `.coffee`            | Supports `#` comments.             | coffeeParser        |
+| EJS          | `.ejs`               | Supports `<!-- -->` and `<%# %>`   | ejsParser           |
+| erb          | `.erb`               | Supports `<!-- -->`                | twigParser          |
+| Erlang       | `.erl`               | Supports `%` comments.             | erlangParser        |
+| Go           | `.go`                | Supports `// and /* */` comments.  | defaultParser       |
+| Haml         | `.haml`              | Supports `/ -# <!-- --> and <%# %>`| twigParser          |
+| HTML         | `.html` `.htm`       | Supports `<!-- -->`                | twigParser          |
+| Handlebars   | `.hbs` `.handlebars` | Supports `{{! }}` and `{{!-- --}}` | hbsParser           |
+| Haskell      | `.hs`                | Supports `--`                      | haskellParser       |
+| Hogan        | `.hgn` `.hogan`      | Supports `{{! }}` and `{{!-- --}}` | hbsParser           |
+| Jade         | `.jade`              | Supports `//` and `//-` comments.  | jadeParser          |
+| Javascript   | `.js` `.es` `.es6`   | Supports `// and /* */` comments   | defaultParser       |
+| Jsx          | `.jsx`               | Supports `// and /* */` comments.  | defaultParser       |
+| Less         | `.less`              | Supports `// and /* */` comments.  | defaultParser       |
+| Mustache     | `.mustache`          | Supports `{{! }}` and `{{!-- --}}` | hbsParser           |
+| Pascal       | `.pas`               | Supports `// and { }` comments.    | pascalParser        |
+| PHP          | `.php`               | Supports `// and /* */` comments.  | defaultParser       |
+| Perl         | `.pl`, `.pm`         | Supports `#` comments.             | coffeeParser        |
+| Python       | `.py`                | Supports `"""` and `#` comments.   | pythonParser        |
+| Ruby         | `.rb`                | Supports `#` comments.             | coffeeParser        |
+| Sass         | `.sass` `.scss`      | Supports `// and /* */` comments.  | defaultParser       |
+| Shell        | `.sh` `.zsh` `.bash` | Supports `#` comments.             | coffeeParser        |
+| SilverStripe | `.ss`                | Supports `<%-- --%>` comments.     | ssParser            |
+| Stylus       | `.styl`              | Supports `// and /* */` comments.  | defaultParser       |
+| Twig         | `.twig`              | Supports `{#  #}` and `<!-- -->`   | twigParser          |
+| Typescript   | `.ts`                | Supports `// and /* */` comments.  | defaultParser       |
 
 Javascript is the default parser.
 
@@ -83,13 +84,14 @@ $ npm install --global leasot
 
   Options:
 
-    -h, --help                 output usage information
-    -V, --version              output the version number
-    -r, --reporter [reporter]  use reporter (table|json|xml|markdown|raw) (default: table)
-    -t, --filetype [filetype]  force the filetype to parse. Useful for streams (default: .js)
-    -T, --tags <tags>          add additional comment types to find (alongside todo & fixme)
-    -S, --skip-unsupported     skip unsupported filetypes
-    -I, --inline-files         parse possible inline files
+    -h, --help                           output usage information
+    -V, --version                        output the version number
+    -r, --reporter [reporter]            use reporter (table|json|xml|markdown|raw) (default: table)
+    -t, --filetype [filetype]            force the filetype to parse. Useful for streams (default: .js)
+    -T, --tags <tags>                    add additional comment types to find (alongside todo & fixme)
+    -S, --skip-unsupported               skip unsupported filetypes
+    -I, --inline-files                   parse possible inline files
+    -A, --associate-parser [ext,parser]  associate unknown extensions with bundled parsers (parser optional / default: defaultParser)
 
   Examples:
 
@@ -160,6 +162,20 @@ var leasot = require('leasot');
 
 `leasot` exposes the following API:
 
+### .associateExtWithParser(parsers)
+
+Associates a bundled parser with a new extension.
+
+The parsers object must be completed in the following format:
+
+```json
+{ 
+    '.cls': { 
+        parserName: 'defaultParser'
+    }
+}
+```
+
 ### .isExtSupported(extension)
 
 Check whether extension is supported by parser.
@@ -178,7 +194,8 @@ Specify an extension including the prefixing dot, for example:
 | `content`           | `string`   | Yes      |         | Content to parse                                      |
 | `fileName`          | `string`   | No       |         | fileName to attach to todos output                    |
 | `customTags`        | `array`    | No       | `[]`    | Additional tags (comment types) to search for (alongside todo & fixme) |
-| `withIncludedFiles` | `boolean` | No       | `false` | Parse also possible included file types (for example: `css` inside a `php` file |
+| `withIncludedFiles` | `boolean`  | No       | `false` | Parse also possible included file types (for example: `css` inside a `php` file |
+| `associateParser`   | `object`   | No       |         | See `.associateExtWithParser` for syntax              |
 
 **Returns**: `array` of comments.
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ var leasot = require('leasot');
 
 Associates a bundled parser with a new extension.
 
-The parsers object must be completed in the following format:
+The `parsers` parameter must be completed in the following format:
 
 ```js
 { 

--- a/bin/leasot.js
+++ b/bin/leasot.js
@@ -8,6 +8,24 @@ function list(val) {
     return val.split(',');
 }
 
+function parseAssociateParser(val, req) {
+    var ext, parser;
+    var data = val.split(',');
+    switch (data.length) {
+        case 2:
+            parser = data[1];
+        case 1:
+            ext = data[0];
+            parser = parser || 'defaultParser';
+            break;
+        default:
+            throw new Error('Incorrectly formatted extension / parser registration. (param: ' + val + ')');
+    }
+
+    req[ext] = { parserName: parser };
+    return req;
+}
+
 program
     .description(pkg.description)
     .version(pkg.version)
@@ -17,6 +35,7 @@ program
     .option('-T, --tags <tags>', 'add additional comment types to find (alongside todo & fixme)', list, [])
     .option('-S, --skip-unsupported', 'skip unsupported filetypes', false)
     .option('-I, --inline-files', 'parse possible inline files', false)
+    .option('-A, --associate-parser [ext,parser]', 'associate unknown extensions with bundled parsers (parser optional / default: defaultParser)', parseAssociateParser, {})
     .on('--help', function () {
         console.log('  Examples:');
         console.log('');

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var parsers = require('./lib/parsers');
 var reporters = require('./lib/reporters');
 
 // expose API
+exports.associateExtWithParser = parsers.associateExtWithParser;
 exports.isExtSupported = parsers.isExtSupported;
 exports.parse = parsers.parse;
 exports.parseLegacy = parsers.parseLegacy;

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -16,8 +16,12 @@ function run(content, params) {
     params = params || {};
     var file = params.file;
     var ext = getFiletype(params.ext, file);
+    var associateParser = params.associateParser;
     var tags = params.tags;
     var withInlineFiles = params.withInlineFiles;
+
+    // Associate extensions with bundled parsers
+    leasot.associateExtWithParser(associateParser);
 
     if (!leasot.isExtSupported(ext)) {
         if (params.skipUnsupported) {
@@ -31,7 +35,8 @@ function run(content, params) {
         content: content,
         fileName: file,
         customTags: tags,
-        withInlineFiles: withInlineFiles
+        withInlineFiles: withInlineFiles,
+        associateParser: associateParser
     });
 }
 
@@ -79,7 +84,8 @@ function readFiles(program) {
                 filetype: program.filetype,
                 tags: program.tags,
                 skipUnsupported: program.skipUnsupported,
-                withInlineFiles: program.inlineFiles
+                withInlineFiles: program.inlineFiles,
+                associateParser: program.associateParser
             });
         }).filter(function (item) {
             return item && item.length;
@@ -98,7 +104,8 @@ module.exports = function (program) {
                 filetype: program.filetype,
                 tags: program.tags,
                 skipUnsupported: program.skipUnsupported,
-                withInlineFiles: program.inlineFiles
+                withInlineFiles: program.inlineFiles,
+                associateParser: program.associateParser
             });
             outputTodos(todos, program.reporter);
         });

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -46,6 +46,19 @@ var parsersDb = {
     '.zsh': { parserName: 'coffeeParser' },
 };
 
+// Support for associating an extension with a parser
+function associateExtWithParser(parsers) {
+    for (var ext in parsers) {
+        if ((ext.length > 1 && ext[0] === '.') !== true)
+            throw new Error('Cannot register extension: invalid extension.');
+        if ((parsers[ext] !== null && parsers[ext].parserName !== undefined && parsers[ext].parserName !== null) !== true)
+            throw new Error('Cannot register extension: parser name missing.');
+    }
+
+    // Add any additional parsers.
+    Object.assign(parsersDb, parsers);
+}
+
 function isExtSupported(ext) {
     return Boolean(parsersDb[ext]);
 }
@@ -56,6 +69,10 @@ function parse(options) {
     var fileName = options.fileName;
     var customTags = options.customTags;
     var withInlineFiles = options.withInlineFiles || false;
+    var associateParser = options.associateParser || {};
+
+    // Associate extensions with bundled parsers
+    associateExtWithParser(associateParser);
 
     if (!isExtSupported(ext)) {
         throw new Error('extension ' + ext + ' is not supported.');
@@ -110,6 +127,7 @@ function parseLegacy(ext, content, fileName, customTags, withInlineFiles) {
     });
 }
 
+exports.associateExtWithParser = associateExtWithParser;
 exports.isExtSupported = isExtSupported;
 exports.parse = parse;
 exports.parseLegacy = parseLegacy;

--- a/tests/cli-spec.js
+++ b/tests/cli-spec.js
@@ -100,6 +100,24 @@ describe('check cli', function () {
         });
     });
 
+    it('should parse file with newly associated extension', function (callback) {
+        testCli(['salesforce-apex.cls'], ['--associate-parser', '.cls,defaultParser'], function (exitCode, log) {
+            should.exist(exitCode);
+            should.exist(log);
+            exitCode.should.equal(1);
+            log.should.eql([
+                '',
+                'tests/fixtures/salesforce-apex.cls',
+                '  line 4  TODO   Add detail',
+                '  line 7  FIXME  do something with the file contents',
+                '',
+                ' ✖ 2 todos/fixmes found',
+                ''
+            ]);
+            callback();
+        });
+    });
+
     it('should get no error exitCode if no todos or fixmes are found', function (callback) {
         testCli(['no-todos.js'], null, function (exitCode, log) {
             should.exist(log);

--- a/tests/fixtures/salesforce-apex.cls
+++ b/tests/fixtures/salesforce-apex.cls
@@ -1,0 +1,9 @@
+public with sharing class MyClass {
+
+    public void MyMethod(String objectType) {
+        // TODO: Add detail
+    }
+
+    /* FIXME do something with the file contents*/
+
+}

--- a/tests/parser-spec.js
+++ b/tests/parser-spec.js
@@ -15,12 +15,14 @@ function getComments(file, options) {
     var withInlineFiles = options.withInlineFiles;
     var content = fs.readFileSync(file, 'utf8');
     var ext = path.extname(file);
+    var associateParser = options.associateParser;
     return leasot.parse({
         ext: ext,
         content: content,
         fileName: file,
         customTags: customTags,
-        withInlineFiles: withInlineFiles
+        withInlineFiles: withInlineFiles,
+        associateParser: associateParser
     });
 }
 
@@ -503,6 +505,27 @@ describe('parsing', function () {
             comments.should.have.length(2);
             verifyComment(comments[0], 'TODO', 2, 'This is a single-line comment');
             verifyComment(comments[1], 'FIXME', 9, 'change this tag from Id to class');
+        });
+    });
+
+    describe('associate parser', function () {
+        it('supports new extension', function () {
+            var association = { '.cls': { parserName: 'defaultParser'} };
+            leasot.associateExtWithParser(association);
+
+            leasot.isExtSupported('.cls').should.equal(true);
+
+        });
+
+        it('parses newly associated file using specified parser', function () {
+            var file = getFixturePath('salesforce-apex.cls');
+            var comments = getComments(file, {
+                associateParser: { '.cls': { parserName: 'defaultParser'} }
+            });
+            should.exist(comments);
+            comments.should.have.length(2);
+            verifyComment(comments[0], 'TODO', 4, 'Add detail');
+            verifyComment(comments[1], 'FIXME', 7, 'do something with the file contents');
         });
     });
 });


### PR DESCRIPTION
- Added support for associating new extensions with bundled parsers at runtime
  - For example: I write a lot of Salesforce Apex but the extension .cls is not associated with a parser.  However, the defaultParser will successfully parse Apex source code.
- Added associateExtWithParser method to API
- Updated README.md to reflect changes
- Added CLI & Parser tests