### PR TITLE
Support references

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ transformHeader: function (kind) {
 
 You are expected to return either an `Array of strings` or just a `string`. If you return an array - each item will be separated by a newline in the output.
 
-### transformComment(file, line, text, kind)
+### transformComment(file, line, text, kind, ref)
 
 Control the output for each comment.
 
@@ -297,7 +297,7 @@ Control the output for each comment.
 
 **Default**:
 ```js
-transformComment: function (file, line, text, kind) {
+transformComment: function (file, line, text, kind, ref) {
     return ['| ' + file + ' | ' + line + ' | ' + text];
 },
 ```
@@ -306,9 +306,11 @@ transformComment: function (file, line, text, kind) {
 
 **line**: line of comment.
 
-**text**: comment text
+**text**: comment text. Default ''.
 
 **kind**: will be be passed as the comment kind (todo/fixme).
+
+**ref**: a reference. Default ''.
 
 **Returns**: `String[]|String`
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ to extract your todos from comments.
 - Supported default types are `TODO` and `FIXME` - case insensitive.
 - Additional types can be added (using `tags` in cli and `customTags` in `leasot.parse`)
 - New extensions can be associated with bundled parsers as many languages have overlapping syntax
-- Supports leading references. E.g. `// TODO(tregusti): Make this better`
+- Supports both leading and trailing references. E.g. `// TODO(tregusti): Make this better` or `// TODO: Text /tregusti`
 
 ## Supported languages:
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ to extract your todos from comments.
 - Supported default types are `TODO` and `FIXME` - case insensitive.
 - Additional types can be added (using `tags` in cli and `customTags` in `leasot.parse`)
 - New extensions can be associated with bundled parsers as many languages have overlapping syntax
+- Supports leading references. E.g. `// TODO(tregusti): Make this better`
 
 ## Supported languages:
 
@@ -204,7 +205,8 @@ Specify an extension including the prefixing dot, for example:
     file: 'parsedFile.js',
     text: 'comment text',
     kind: 'TODO',
-    line: 8
+    line: 8,
+    ref: 'reference'
 }]
 ```
 

--- a/lib/reporters/custom.js
+++ b/lib/reporters/custom.js
@@ -15,7 +15,7 @@ function getTransformedComments(todos, config) {
         var kind = comment.kind;
         mem[kind] = mem[kind] || [];
         // transformed comment as an array item
-        var transformedComment = transformFn(comment.file, comment.line, comment.text, kind);
+        var transformedComment = transformFn(comment.file, comment.line, comment.text, kind, comment.ref);
         // enforce array type
         if (!Array.isArray(transformedComment)) {
             transformedComment = [transformedComment];
@@ -54,9 +54,9 @@ function parseConfig(_config) {
     var config = defaults(_config || {}, {
         padding: 2,
         newLine: os.EOL,
-        transformComment: function (file, line, text, kind) {
+        transformComment: function (file, line, text, kind, ref) {
             //jshint unused:false
-            return ['file: ' + file, 'line: ' + line, 'text: ' + text];
+            return ['file: ' + file, 'line: ' + line, 'text: ' + text, 'ref:' + ref];
         },
         transformHeader: function (kind) {
             return ['kind: ' + kind];

--- a/lib/reporters/markdown.js
+++ b/lib/reporters/markdown.js
@@ -7,8 +7,9 @@ function parseConfig(_config) {
     var config = defaults(_config || {}, {
         padding: 2,
         newLine: os.EOL,
-        transformComment: function (file, line, text, kind) {
+        transformComment: function (file, line, text, kind, ref) {
             //jshint unused:false
+            if (ref) text = '@' + ref + ' ' + text;
             return ['| ' + file + ' | ' + line + ' | ' + text];
         },
         transformHeader: function (kind) {

--- a/lib/reporters/table.js
+++ b/lib/reporters/table.js
@@ -17,10 +17,14 @@ function outputTable(todos) {
     var headers = [];
     var prevfile;
     var t = table(todos.map(function (el, i) {
+        var text = chalk.cyan(el.text);
+        if (el.ref) {
+            text = chalk.gray('@' + el.ref) + ' ' + text;
+        }
         var line = ['',
             chalk.gray('line ' + el.line),
             chalk.green(el.kind),
-            chalk.cyan(el.text)
+            text
         ];
         if (el.file !== prevfile) {
             headers[i] = el.file;

--- a/lib/utils/comments.js
+++ b/lib/utils/comments.js
@@ -6,20 +6,22 @@ function getRegex(customTags) {
         tags = tags.concat(customTags);
     }
 
-    return '\\s*@?(' + tags.join('|') + ')\\s*:?\\s*(.*?)\\s*';
+    return '\\s*@?(' + tags.join('|') + ')\\s*(?:\\(([^)]*)\\))?\\s*:?\\s*(.*?)\\s*';
 }
 
 function prepareComment(match, line, file) {
-    // match = [ <entire_match>, required <kind>, <text> ]
+    // match = [ <entire_match>, required <kind>, <reference>, <text> ]
     if (!match || !match[1]) {
         return null;
     }
-    var text = match[2] || '';
+    var ref = match[2] || '';
+    var text = match[3] || '';
     return {
         file: file || 'unknown file',
         kind: match[1].toUpperCase(),
         line: line,
         text: text.trim(),
+        ref:  ref.trim()
     };
 }
 

--- a/lib/utils/comments.js
+++ b/lib/utils/comments.js
@@ -6,15 +6,15 @@ function getRegex(customTags) {
         tags = tags.concat(customTags);
     }
 
-    return '\\s*@?(' + tags.join('|') + ')\\s*(?:\\(([^)]*)\\))?\\s*:?\\s*(.*?)\\s*';
+    return '\\s*@?(' + tags.join('|') + ')\\s*(?:\\(([^)]*)\\))?\\s*:?\\s*(.*?)\\s*\\s*(?:/(.*)\\s*)?';
 }
 
 function prepareComment(match, line, file) {
-    // match = [ <entire_match>, required <kind>, <reference>, <text> ]
+    // match = [ <entire_match>, required <kind>, <reference>, <text>, <reference> ]
     if (!match || !match[1]) {
         return null;
     }
-    var ref = match[2] || '';
+    var ref = match[2] || match[4] ||'';
     var text = match[3] || '';
     return {
         file: file || 'unknown file',

--- a/tests/fixtures/reference-leading.js
+++ b/tests/fixtures/reference-leading.js
@@ -1,0 +1,5 @@
+'use strict';
+
+// TODO(tregusti): Use Symbol instead
+const hello = 'HELLO';
+

--- a/tests/fixtures/reference-trailing.rb
+++ b/tests/fixtures/reference-trailing.rb
@@ -1,0 +1,5 @@
+def fixit()
+  # FIXME: Make it better /tregusti
+  puts 'Fixed'
+end
+

--- a/tests/parser-spec.js
+++ b/tests/parser-spec.js
@@ -26,10 +26,14 @@ function getComments(file, options) {
     });
 }
 
-function verifyComment(actual, kind, line, text) {
+function verifyComment(actual, kind, line, text, ref) {
+    ref = arguments.length === 5 ? ref : null;
     actual.kind.should.equal(kind);
     actual.line.should.equal(line);
     actual.text.should.equal(text);
+    if (ref !== null) {
+        actual.ref.should.equal(ref);
+    }
 }
 
 describe('parsing', function () {
@@ -526,6 +530,15 @@ describe('parsing', function () {
             comments.should.have.length(2);
             verifyComment(comments[0], 'TODO', 4, 'Add detail');
             verifyComment(comments[1], 'FIXME', 7, 'do something with the file contents');
+        });
+    });
+
+    describe('references', function() {
+        it('leading', function() {
+            var file = getFixturePath('reference-leading.js');
+            var comments = getComments(file);
+            comments.should.have.length(1);
+            verifyComment(comments[0], 'TODO', 3, 'Use Symbol instead', 'tregusti');
         });
     });
 });

--- a/tests/parser-spec.js
+++ b/tests/parser-spec.js
@@ -540,5 +540,11 @@ describe('parsing', function () {
             comments.should.have.length(1);
             verifyComment(comments[0], 'TODO', 3, 'Use Symbol instead', 'tregusti');
         });
+        it('trailing', function() {
+            var file = getFixturePath('reference-trailing.rb');
+            var comments = getComments(file);
+            comments.should.have.length(1);
+            verifyComment(comments[0], 'FIXME', 2, 'Make it better', 'tregusti');
+        });
     });
 });


### PR DESCRIPTION
This pull request add support for add a reference (to a team, person, project, etc.) within the comment in one of two ways. Personally I often use this in the projects I'm working. Either to tag a comment as mine, or assign another person to fix something later.

1. trailing: `// TODO: Do this later /tregusti`
1. leading (will override trailing): `// TODO(tregusti): Do this later`

I have added docs for it, and also added it to the default reporters. And of course tests for the parser, no tests for the reporters though since I couldn't find any existing.

Table output looks like this:

![image](https://cloud.githubusercontent.com/assets/1891942/13828449/d4e3cdf8-ebc1-11e5-98d1-8e300ffed67b.png)
