### PR TITLE
Add support for Vue components

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,40 +27,41 @@ to extract your todos from comments.
 
 ## Supported languages:
 
-| Filetype     | Extension            | Notes                              | Parser Name         |
-| ------------ | -------------------- | -----------------------------------| ------------------- |
-| C#           | `.cs`                | Supports `// and /* */` comments.  | defaultParser       |
-| C++/C        | `.cpp` `.c` `.h`     | Supports `// and /* */` comments.  | defaultParser       |
-| Coffee-React | `.cjsx`              | Supports `#` comments.             | coffeeParser        |
-| Coffeescript | `.coffee`            | Supports `#` comments.             | coffeeParser        |
-| CSon         | `.cson`              | Supports `#` comments.             | coffeeParser        |
-| CSS          | `.css`               | Supports `/* */` comments.         | defaultParser       |
-| EJS          | `.ejs`               | Supports `<!-- -->` and `<%# %>`   | ejsParser           |
-| Erb          | `.erb`               | Supports `<!-- -->` and `<%# %>`   | ejsParser           |
-| Erlang       | `.erl` `.hrl`        | Supports `%` comments.             | erlangParser        |
-| Go           | `.go`                | Supports `// and /* */` comments.  | defaultParser       |
-| Haml         | `.haml`              | Supports `/ -# <!-- --> and <%# %>`| twigParser          |
-| Handlebars   | `.hbs` `.handlebars` | Supports `{{! }}` and `{{!-- --}}` | hbsParser           |
-| Haskell      | `.hs`                | Supports `--`                      | haskellParser       |
-| Hogan        | `.hgn` `.hogan`      | Supports `{{! }}` and `{{!-- --}}` | hbsParser           |
-| HTML         | `.html` `.htm`       | Supports `<!-- -->`                | twigParser          |
-| Nunjucks     | `.njk`               | Supports `{#  #}` and `<!-- -->`   | twigParser          |
-| Jade         | `.jade` `.pug`       | Supports `//` and `//-` comments.  | jadeParser          |
-| Javascript   | `.js` `.es` `.es6`   | Supports `// and /* */` comments   | defaultParser       |
-| Jsx          | `.jsx`               | Supports `// and /* */` comments.  | defaultParser       |
-| Less         | `.less`              | Supports `// and /* */` comments.  | defaultParser       |
-| Mustache     | `.mustache`          | Supports `{{! }}` and `{{!-- --}}` | hbsParser           |
-| Pascal       | `.pas`               | Supports `// and { }` comments.    | pascalParser        |
-| Perl         | `.pl`, `.pm`         | Supports `#` comments.             | coffeeParser        |
-| PHP          | `.php`               | Supports `// and /* */` comments.  | defaultParser       |
-| Python       | `.py`                | Supports `"""` and `#` comments.   | pythonParser        |
-| Ruby         | `.rb`                | Supports `#` comments.             | coffeeParser        |
-| Sass         | `.sass` `.scss`      | Supports `// and /* */` comments.  | defaultParser       |
-| Shell        | `.sh` `.zsh` `.bash` | Supports `#` comments.             | coffeeParser        |
-| SilverStripe | `.ss`                | Supports `<%-- --%>` comments.     | ssParser            |
-| Stylus       | `.styl`              | Supports `// and /* */` comments.  | defaultParser       |
-| Twig         | `.twig`              | Supports `{#  #}` and `<!-- -->`   | twigParser          |
-| Typescript   | `.ts`                | Supports `// and /* */` comments.  | defaultParser       |
+| Filetype     | Extension            | Notes                                      | Parser Name         |
+| ------------ | -------------------- | -------------------------------------------| ------------------- |
+| C#           | `.cs`                | Supports `// and /* */` comments.          | defaultParser       |
+| C++/C        | `.cpp` `.c` `.h`     | Supports `// and /* */` comments.          | defaultParser       |
+| Coffee-React | `.cjsx`              | Supports `#` comments.                     | coffeeParser        |
+| Coffeescript | `.coffee`            | Supports `#` comments.                     | coffeeParser        |
+| CSon         | `.cson`              | Supports `#` comments.                     | coffeeParser        |
+| CSS          | `.css`               | Supports `/* */` comments.                 | defaultParser       |
+| EJS          | `.ejs`               | Supports `<!-- -->` and `<%# %>`           | ejsParser           |
+| Erb          | `.erb`               | Supports `<!-- -->` and `<%# %>`           | ejsParser           |
+| Erlang       | `.erl` `.hrl`        | Supports `%` comments.                     | erlangParser        |
+| Go           | `.go`                | Supports `// and /* */` comments.          | defaultParser       |
+| Haml         | `.haml`              | Supports `/ -# <!-- --> and <%# %>`        | twigParser          |
+| Handlebars   | `.hbs` `.handlebars` | Supports `{{! }}` and `{{!-- --}}`         | hbsParser           |
+| Haskell      | `.hs`                | Supports `--`                              | haskellParser       |
+| Hogan        | `.hgn` `.hogan`      | Supports `{{! }}` and `{{!-- --}}`         | hbsParser           |
+| HTML         | `.html` `.htm`       | Supports `<!-- -->`                        | twigParser          |
+| Nunjucks     | `.njk`               | Supports `{#  #}` and `<!-- -->`           | twigParser          |
+| Jade         | `.jade` `.pug`       | Supports `//` and `//-` comments.          | jadeParser          |
+| Javascript   | `.js` `.es` `.es6`   | Supports `// and /* */` comments           | defaultParser       |
+| Jsx          | `.jsx`               | Supports `// and /* */` comments.          | defaultParser       |
+| Less         | `.less`              | Supports `// and /* */` comments.          | defaultParser       |
+| Mustache     | `.mustache`          | Supports `{{! }}` and `{{!-- --}}`         | hbsParser           |
+| Pascal       | `.pas`               | Supports `// and { }` comments.            | pascalParser        |
+| Perl         | `.pl`, `.pm`         | Supports `#` comments.                     | coffeeParser        |
+| PHP          | `.php`               | Supports `// and /* */` comments.          | defaultParser       |
+| Python       | `.py`                | Supports `"""` and `#` comments.           | pythonParser        |
+| Ruby         | `.rb`                | Supports `#` comments.                     | coffeeParser        |
+| Sass         | `.sass` `.scss`      | Supports `// and /* */` comments.          | defaultParser       |
+| Shell        | `.sh` `.zsh` `.bash` | Supports `#` comments.                     | coffeeParser        |
+| SilverStripe | `.ss`                | Supports `<%-- --%>` comments.             | ssParser            |
+| Stylus       | `.styl`              | Supports `// and /* */` comments.          | defaultParser       |
+| Twig         | `.twig`              | Supports `{#  #}` and `<!-- -->`           | twigParser          |
+| Typescript   | `.ts`                | Supports `// and /* */` comments.          | defaultParser       |
+| Vue          | `.vue`               | Supports `//` `/* */` `<!-- -->` comments. | twigParser          |
 
 Javascript is the default parser.
 

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -47,6 +47,7 @@ var parsersDb = {
     '.styl': { parserName: 'defaultParser' },
     '.ts': { parserName: 'defaultParser' },
     '.twig': { parserName: 'twigParser' },
+    '.vue': { parserName: 'twigParser', includedFiles: ['.html', '.js', '.css'] },
     '.zsh': { parserName: 'coffeeParser' },
 };
 

--- a/tests/fixtures/vue.vue
+++ b/tests/fixtures/vue.vue
@@ -1,0 +1,23 @@
+<template>
+  <!-- TODO: Vue template comment -->
+  <p>{{ greeting }} World!</p>
+</template>
+
+<script>
+/* TODO: Vue script comment */
+module.exports = {
+  data: function () {
+    return {
+      greeting: 'Hello Leasot!'
+    }
+  }
+}
+</script>
+
+<style lang="less" scoped>
+p {
+  font-size: 2em;
+  // FIXME: Vue style comment
+  text-align: center;
+}
+</style>

--- a/tests/parser-spec.js
+++ b/tests/parser-spec.js
@@ -514,6 +514,28 @@ describe('parsing', function () {
         });
     });
 
+    describe('vue', function () {
+        it('parses a vue file without included files', function () {
+            var file = getFixturePath('vue.vue');
+            var comments = getComments(file, {
+                withInlineFiles: false
+            });
+            comments.should.have.length(1);
+            verifyComment(comments[0], 'TODO', 2, 'Vue template comment');
+        });
+
+        it('parses a vue file with just php', function () {
+            var file = getFixturePath('vue.vue');
+            var comments = getComments(file, {
+                withInlineFiles: true
+            });
+            comments.should.have.length(3);
+            verifyComment(comments[0], 'TODO', 2, 'Vue template comment');
+            verifyComment(comments[1], 'TODO', 7, 'Vue script comment');
+            verifyComment(comments[2], 'FIXME', 20, 'Vue style comment');
+        });
+    });
+
     describe('associate parser', function () {
         it('supports new extension', function () {
             var association = { '.cls': { parserName: 'defaultParser'} };


### PR DESCRIPTION
Hi Gilad,
Would be great if leasot could support .vue components.
I have added .vue into supported parsers, it's based on twigParser including html, js, css files.
Unit test was created as well.

If there's any red flag I might miss let me know.

Best,
Peter