### PR TITLE
Support array of parsers when associating parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,14 @@ The `parsers` parameter must be completed in the following format:
     }
 }
 ```
-
+The `parserName` property can also be an array of parsers.
+```js
+{
+    '.sql': {
+        parserName: ['defaultParser', 'haskellParser']
+    }
+}
+```
 ### .isExtSupported(extension)
 
 Check whether extension is supported by parser.

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -98,7 +98,7 @@ function parse(options) {
         customTags: customTags
     };
     var originalParser = parsersDb[ext];
-    var parsers = Array.isArray(originalParser.parserName) ? [...originalParser.parserName] : [originalParser.parserName];
+    var parsers = [].concat(originalParser.parserName);
 
     var includedFiles = originalParser.includedFiles || [];
     if (withInlineFiles) {

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -98,7 +98,7 @@ function parse(options) {
         customTags: customTags
     };
     var originalParser = parsersDb[ext];
-    var parsers = [originalParser.parserName];
+    var parsers = Array.isArray(originalParser.parserName) ? [...originalParser.parserName] : [originalParser.parserName];
 
     var includedFiles = originalParser.includedFiles || [];
     if (withInlineFiles) {

--- a/tests/fixtures/sql.sql
+++ b/tests/fixtures/sql.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE FUNCTION "USER"."F_TEST"
+/*
+  Test function
+  @TODO: Sql multi comment
+*/
+( aParam VARCHAR2 )
+RETURN VARCHAR2 AS
+BEGIN
+
+  -- TODO Sql single comment
+  RETURN '1';
+
+END F_TEST;
+/

--- a/tests/parser-spec.js
+++ b/tests/parser-spec.js
@@ -575,6 +575,17 @@ describe('parsing', function () {
             verifyComment(comments[0], 'TODO', 4, 'Add detail');
             verifyComment(comments[1], 'FIXME', 7, 'do something with the file contents');
         });
+
+        it('parses newly associated file using multiple parsers', function () {
+            var file = getFixturePath('sql.sql');
+            var comments = getComments(file, {
+                associateParser: { '.sql': { parserName: ['defaultParser', 'haskellParser']} }
+            });
+            should.exist(comments);
+            comments.should.have.length(2);
+            verifyComment(comments[0], 'TODO', 4, 'Sql multi comment');
+            verifyComment(comments[1], 'TODO', 10, 'Sql single comment');
+        });
     });
 
     describe('references', function() {


### PR DESCRIPTION
Adding multiple parsers option (arrray) to `parserName` parameter in `associateExtWithParser` function.

 Example.
` '{.sql': {parserName: ['defaultParser', 'haskellParser']}} `