### PR TITLE
Exit with success when TODOs are output

### DIFF
--- a/bin/leasot-reporter.js
+++ b/bin/leasot-reporter.js
@@ -14,6 +14,7 @@ program
     .usage('[options] <file ...>')
     .option('-i, --ignore <patterns>', 'add ignore patterns', list, [])
     .option('-r, --reporter [reporter]', 'use reporter (table|json|xml|markdown|raw) (default: table)', 'table')
+    .option('-x, --exit-nicely', 'exit with 0 when output is produced', false)
     .on('--help', function () {
         console.log('  Examples:');
         console.log('');

--- a/bin/leasot.js
+++ b/bin/leasot.js
@@ -34,6 +34,7 @@ program
     .option('-S, --skip-unsupported', 'skip unsupported filetypes', false)
     .option('-t, --filetype [filetype]', 'force the filetype to parse. Useful for streams (default: .js)')
     .option('-T, --tags <tags>', 'add additional comment types to find (alongside todo & fixme)', list, [])
+    .option('-x, --exit-nicely', 'exit with 0 when output is produced', false)
     .on('--help', function () {
         console.log('  Examples:');
         console.log('');

--- a/lib/cli-reporter.js
+++ b/lib/cli-reporter.js
@@ -17,7 +17,7 @@ function outputTodos(todos, reporter) {
     } catch (e) {
         console.error(e);
     }
-    process.exit(todos.length ? 0 : 1);
+    process.exit(todos.length ? 1 : 0);
 }
 
 function parseAndReportFiles(fileGlobs, program) {

--- a/lib/cli-reporter.js
+++ b/lib/cli-reporter.js
@@ -17,7 +17,7 @@ function outputTodos(todos, reporter) {
     } catch (e) {
         console.error(e);
     }
-    process.exit(todos.length ? 1 : 0);
+    process.exit(todos.length ? 0 : 1);
 }
 
 function parseAndReportFiles(fileGlobs, program) {

--- a/lib/cli-reporter.js
+++ b/lib/cli-reporter.js
@@ -8,15 +8,16 @@ var path = require('path');
 var leasot = require('../index');
 var concurrencyLimit = 50;
 
-function outputTodos(todos, reporter) {
+function outputTodos(todos, params) {
     try {
         var output = leasot.reporter(todos, {
-            reporter: reporter
+            reporter: params.reporter
         });
         console.log(output);
     } catch (e) {
         console.error(e);
     }
+    if (params.exitNicely) process.exit(0)
     process.exit(todos.length ? 1 : 0);
 }
 
@@ -54,7 +55,7 @@ function parseAndReportFiles(fileGlobs, program) {
             return items.concat(item);
         }, []);
 
-        outputTodos(todos, program.reporter);
+        outputTodos(todos, program);
     });
 }
 
@@ -62,7 +63,7 @@ module.exports = function (program) {
     if (!process.stdin.isTTY) {
         return getStdin().then(function (content) {
             var todos = JSON.parse(content);
-            outputTodos(todos, program.reporter);
+            outputTodos(todos, program);
         }).catch(function (e) {
             console.error(e);
             process.exit(1);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -53,7 +53,7 @@ function outputTodos(todos, reporter) {
     } catch (e) {
         console.error(e);
     }
-    process.exit(todos.length ? 1 : 0);
+    process.exit(todos.length ? 0 : 1);
 }
 
 function parseAndReportFiles(fileGlobs, program) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -53,7 +53,7 @@ function outputTodos(todos, reporter) {
     } catch (e) {
         console.error(e);
     }
-    process.exit(todos.length ? 0 : 1);
+    process.exit(todos.length ? 1 : 0);
 }
 
 function parseAndReportFiles(fileGlobs, program) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -44,16 +44,18 @@ function parseContentSync(content, params) {
     });
 }
 
-function outputTodos(todos, reporter) {
+function outputTodos(todos, params) {
     try {
         var output = leasot.reporter(todos, {
-            reporter: reporter
+            reporter: params.reporter
         });
         console.log(output);
     } catch (e) {
         console.error(e);
     }
+    if (params.exitNicely) process.exit(0);
     process.exit(todos.length ? 1 : 0);
+
 }
 
 function parseAndReportFiles(fileGlobs, program) {
@@ -91,7 +93,7 @@ function parseAndReportFiles(fileGlobs, program) {
             return items.concat(item);
         }, []);
 
-        outputTodos(todos, program.reporter);
+        outputTodos(todos, program);
     });
 }
 
@@ -105,7 +107,7 @@ module.exports = function (program) {
         return getStdin()
             .then(function (content) {
                 var todos = parseContentSync(content, program);
-                outputTodos(todos, program.reporter);
+                outputTodos(todos, program);
             })
             .catch(function (e) {
                 console.error(e);

--- a/tests/cli-spec.js
+++ b/tests/cli-spec.js
@@ -43,7 +43,7 @@ describe('check cli', function () {
         testCli(['block.less', 'coffee.coffee'], null, function (exitCode, log) {
             should.exist(exitCode);
             should.exist(log);
-            exitCode.should.equal(1);
+            exitCode.should.equal(0);
             log.should.eql([
                 '',
                 'tests/fixtures/block.less',
@@ -67,7 +67,7 @@ describe('check cli', function () {
         testCli(['*.styl'], null, function (exitCode, log) {
             should.exist(exitCode);
             should.exist(log);
-            exitCode.should.equal(1);
+            exitCode.should.equal(0);
             log.should.eql([
                 '',
                 'tests/fixtures/block.styl',
@@ -101,7 +101,7 @@ describe('check cli', function () {
         testCli(['file.unsupported'], ['--skip-unsupported'], function (exitCode, log) {
             should.exist(exitCode);
             should.exist(log);
-            exitCode.should.equal(0);
+            exitCode.should.equal(1);
             log.should.eql([
                 '',
                 '',
@@ -129,7 +129,7 @@ describe('check cli', function () {
         testCli(['salesforce-apex.cls'], ['--associate-parser', '.cls,defaultParser'], function (exitCode, log) {
             should.exist(exitCode);
             should.exist(log);
-            exitCode.should.equal(1);
+            exitCode.should.equal(0);
             log.should.eql([
                 '',
                 'tests/fixtures/salesforce-apex.cls',
@@ -147,7 +147,7 @@ describe('check cli', function () {
         testCli(['no-todos.js'], null, function (exitCode, log) {
             should.exist(log);
             should.exist(exitCode);
-            exitCode.should.equal(0);
+            exitCode.should.equal(1);
             log.should.eql([
                 '',
                 '',
@@ -162,7 +162,7 @@ describe('check cli', function () {
         testCli(['*.styl'], ['--ignore', '**/block.styl'], function (exitCode, log) {
             should.exist(exitCode);
             should.exist(log);
-            exitCode.should.equal(1);
+            exitCode.should.equal(0);
             log.should.eql([
                 '',
                 'tests/fixtures/line.styl',

--- a/tests/cli-spec.js
+++ b/tests/cli-spec.js
@@ -43,7 +43,7 @@ describe('check cli', function () {
         testCli(['block.less', 'coffee.coffee'], null, function (exitCode, log) {
             should.exist(exitCode);
             should.exist(log);
-            exitCode.should.equal(0);
+            exitCode.should.equal(1);
             log.should.eql([
                 '',
                 'tests/fixtures/block.less',
@@ -67,7 +67,7 @@ describe('check cli', function () {
         testCli(['*.styl'], null, function (exitCode, log) {
             should.exist(exitCode);
             should.exist(log);
-            exitCode.should.equal(0);
+            exitCode.should.equal(1);
             log.should.eql([
                 '',
                 'tests/fixtures/block.styl',
@@ -101,7 +101,7 @@ describe('check cli', function () {
         testCli(['file.unsupported'], ['--skip-unsupported'], function (exitCode, log) {
             should.exist(exitCode);
             should.exist(log);
-            exitCode.should.equal(1);
+            exitCode.should.equal(0);
             log.should.eql([
                 '',
                 '',
@@ -129,7 +129,7 @@ describe('check cli', function () {
         testCli(['salesforce-apex.cls'], ['--associate-parser', '.cls,defaultParser'], function (exitCode, log) {
             should.exist(exitCode);
             should.exist(log);
-            exitCode.should.equal(0);
+            exitCode.should.equal(1);
             log.should.eql([
                 '',
                 'tests/fixtures/salesforce-apex.cls',
@@ -147,7 +147,7 @@ describe('check cli', function () {
         testCli(['no-todos.js'], null, function (exitCode, log) {
             should.exist(log);
             should.exist(exitCode);
-            exitCode.should.equal(1);
+            exitCode.should.equal(0);
             log.should.eql([
                 '',
                 '',
@@ -162,7 +162,7 @@ describe('check cli', function () {
         testCli(['*.styl'], ['--ignore', '**/block.styl'], function (exitCode, log) {
             should.exist(exitCode);
             should.exist(log);
-            exitCode.should.equal(0);
+            exitCode.should.equal(1);
             log.should.eql([
                 '',
                 'tests/fixtures/line.styl',

--- a/tests/cli-spec.js
+++ b/tests/cli-spec.js
@@ -174,4 +174,23 @@ describe('check cli', function () {
             callback();
         });
     });
+
+    it('should exit with 0 on output', function (callback) {
+        this.timeout(10000);
+        testCli(['coffee.coffee'], ['--exit-nicely'], null, function (exitCode, log) {
+            should.exist(exitCode);
+            should.exist(log);
+            exitCode.should.equal(0);
+            log.should.eql([
+                '',
+                'tests/fixtures/coffee.coffee',
+                '  line 1   TODO   Do something',
+                '  line 3   FIXME  Fix something',
+                '',
+                ' ✖ 2 todos/fixmes found',
+                ''
+            ]);
+            callback();
+        });
+    });
 });

--- a/tests/cli-spec.js
+++ b/tests/cli-spec.js
@@ -177,15 +177,15 @@ describe('check cli', function () {
 
     it('should exit with 0 on output', function (callback) {
         this.timeout(10000);
-        testCli(['coffee.coffee'], ['--exit-nicely'], null, function (exitCode, log) {
+        testCli(['coffee.coffee'], ['--exit-nicely'], function (exitCode, log) {
             should.exist(exitCode);
             should.exist(log);
             exitCode.should.equal(0);
             log.should.eql([
                 '',
                 'tests/fixtures/coffee.coffee',
-                '  line 1   TODO   Do something',
-                '  line 3   FIXME  Fix something',
+                '  line 1  TODO   Do something',
+                '  line 3  FIXME  Fix something',
                 '',
                 ' ✖ 2 todos/fixmes found',
                 ''


### PR DESCRIPTION
I have a wrapper script that calls leasot, but the wrapper can't determine when leasot has successfully provided an outout of TODOs versus when leasot has errored out. Errors in leasot generally exit with a code of 1 (as one would typically expect), but successful TODO output also exits with 1.

This PR changes the exit code on successful TODO output to 0.
