### PR TITLE
Add markdown reporter for vscode

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ $ leasot --help
     -A, --associate-parser [ext,parser]  associate unknown extensions with bundled parsers (parser optional / default: defaultParser)
     -i, --ignore <patterns>              add ignore patterns
     -I, --inline-files                   parse possible inline files
-    -r, --reporter [reporter]            use reporter (table|json|xml|markdown|raw) (default: table)
+    -r, --reporter [reporter]            use reporter (table|json|xml|markdown|vscode|raw) (default: table)
     -S, --skip-unsupported               skip unsupported filetypes
     -t, --filetype [filetype]            force the filetype to parse. Useful for streams (default: .js)
     -T, --tags <tags>                    add additional comment types to find (alongside todo & fixme)
@@ -286,6 +286,7 @@ Could also be a custom function `(comments, config)`
 - raw
 - table
 - markdown
+- vscode
 
 Each reporter might contain config params that are useful only for that reporter:
 
@@ -361,6 +362,12 @@ transformComment: function (file, line, text, kind, ref) {
 **Returns**: `String[]|String`
 
 You are expected to return either an `Array of strings` or just a `string`. If you return an array - each item will be separated by a newline in the output.
+
+### VSCode
+
+Returns a markdown version of the todos customized for Visual Studio Code. The file names are
+transformed as URLs and the line numbers as anchors which makes them clickable when the markdown
+content produced with this reporter is opened on Visual Studio Code.
 
 ### Table
 

--- a/bin/leasot-reporter.js
+++ b/bin/leasot-reporter.js
@@ -13,7 +13,7 @@ program
     .version(pkg.version)
     .usage('[options] <file ...>')
     .option('-i, --ignore <patterns>', 'add ignore patterns', list, [])
-    .option('-r, --reporter [reporter]', 'use reporter (table|json|xml|markdown|raw) (default: table)', 'table')
+    .option('-r, --reporter [reporter]', 'use reporter (table|json|xml|markdown|vscode|raw) (default: table)', 'table')
     .option('-x, --exit-nicely', 'exit with exit code 0 even if todos/fixmes are found', false)
     .on('--help', function () {
         console.log('  Examples:');

--- a/bin/leasot.js
+++ b/bin/leasot.js
@@ -30,7 +30,7 @@ program
     )
     .option('-i, --ignore <patterns>', 'add ignore patterns', list, [])
     .option('-I, --inline-files', 'parse possible inline files', false)
-    .option('-r, --reporter [reporter]', 'use reporter (table|json|xml|markdown|raw) (default: table)', 'table')
+    .option('-r, --reporter [reporter]', 'use reporter (table|json|xml|markdown|vscode|raw) (default: table)', 'table')
     .option('-S, --skip-unsupported', 'skip unsupported filetypes', false)
     .option('-t, --filetype [filetype]', 'force the filetype to parse. Useful for streams (default: .js)')
     .option('-T, --tags <tags>', 'add additional comment types to find (alongside todo & fixme)', list, [])

--- a/lib/reporters/vscode.js
+++ b/lib/reporters/vscode.js
@@ -1,0 +1,41 @@
+'use strict';
+var os = require('os');
+var defaults = require('lodash/defaults');
+
+var customReporter = require('./custom');
+
+function parseConfig(_config) {
+    var config = defaults(_config || {}, {
+        padding: 2,
+        newLine: os.EOL,
+        transformComment: function (file, line, text, kind, ref) {
+            //jshint unused:false
+            if (ref) {
+                text = '@' + ref + ' ' + text;
+            }
+            return ['| [' + file + '](' + file + '#'+ line + ') | ' + line + ' | ' + text];
+        },
+        transformHeader: function (kind) {
+            return ['### ' + kind + 's',
+                '| Filename | line # | ' + kind,
+                '|:------|:------:|:------'
+            ];
+        }
+    });
+    if (typeof config.transformHeader !== 'function') {
+        throw new Error('transformHeader must be a function');
+    }
+    if (typeof config.transformComment !== 'function') {
+        throw new Error('transformComment must be a function');
+    }
+    // padding must be a minimum of 0
+    // enforce padding to be a number as well
+    config.padding = Math.max(0, parseInt(config.padding, 10));
+    return config;
+}
+
+module.exports = function (todos, _config) {
+    var config = parseConfig(_config);
+    var output = customReporter.getTransformedComments(todos, config);
+    return customReporter.joinBlocksByHeaders(output, config);
+};


### PR DESCRIPTION
This is a copy of the markdown reporter producing file names as URLs with the line numbers as link anchors. In vscode this format is used to directly point to the correct line number when clicked on the markdown link

usage:
`
leasot -r vscode > TODO.md
`