### PR TITLE
Fix TypeError: Cannot read property 'parserName' of undefined

### DIFF
--- a/src/lib/parsers.ts
+++ b/src/lib/parsers.ts
@@ -58,7 +58,7 @@ const parsersDb: ExtensionsDb = {
     '.tsx': { parserName: 'defaultParser' },
     '.twig': { parserName: 'twigParser' },
     '.vue': { parserName: 'twigParser', includedFiles: ['.html', '.js', '.css'] },
-    '.yaml': { parserName: 'coffeeParser', includedFiles: ['.yml'] },
+    '.yaml': { parserName: 'coffeeParser' },
     '.yml': { parserName: 'coffeeParser' },
     '.zsh': { parserName: 'coffeeParser' },
 };

--- a/src/lib/parsers.ts
+++ b/src/lib/parsers.ts
@@ -59,6 +59,7 @@ const parsersDb: ExtensionsDb = {
     '.twig': { parserName: 'twigParser' },
     '.vue': { parserName: 'twigParser', includedFiles: ['.html', '.js', '.css'] },
     '.yaml': { parserName: 'coffeeParser', includedFiles: ['.yml'] },
+    '.yml': { parserName: 'coffeeParser' },
     '.zsh': { parserName: 'coffeeParser' },
 };
 

--- a/tests/fixtures/yaml.yml
+++ b/tests/fixtures/yaml.yml
@@ -1,0 +1,15 @@
+---
+# Routes
+router:
+  routes:
+    # Fetch route
+    fetch:
+      # TODO: Support POST
+      method: "GET"
+      path: "/"
+    update:
+      # TODO Support params
+      method: "POST"
+      path: "/update"
+
+# TODO: complete file

--- a/tests/parser-spec.ts
+++ b/tests/parser-spec.ts
@@ -425,6 +425,16 @@ describe('parsing', function() {
         });
     });
 
+    describe('yml', function() {
+        it('handle # comments', function() {
+            const file = getFixturePath('yaml.yml');
+            const comments = getComments(file);
+            should.exist(comments);
+            comments.should.have.length(3);
+            verifyComment(comments[0], 'TODO', 7, 'Support POST');
+        });
+    });
+
     describe('bash', function() {
         it('handle # comments', function() {
             const file = getFixturePath('bash.bash');

--- a/tests/parser-spec.ts
+++ b/tests/parser-spec.ts
@@ -416,6 +416,13 @@ describe('parsing', function() {
             comments.should.have.length(3);
             verifyComment(comments[0], 'TODO', 7, 'Support POST');
         });
+        it('handle # comments with withInlineFiles', function() {
+            const file = getFixturePath('yaml.yaml');
+            const comments = getComments(file, { withInlineFiles: true });
+            should.exist(comments);
+            comments.should.have.length(3);
+            verifyComment(comments[0], 'TODO', 7, 'Support POST');
+        });
     });
 
     describe('bash', function() {


### PR DESCRIPTION
Version: leasot@^7.0.0-rc.6

Steps to Reproduce:

```js
require('leasot').parse('', { extension: '.yaml', withInlineFiles: true })
```

Actual:

```
TypeError: Cannot read property 'parserName' of undefined
    at includedFiles.forEach.includedExtension (REDUCTED/node_modules/leasot/dist/lib/parsers.js:111:69)
    at Array.forEach (<anonymous>)
    at getActiveParserNames (REDUCTED/node_modules/leasot/dist/lib/parsers.js:108:19)
    at Object.exports.parse (REDUCTED/node_modules/leasot/dist/lib/parsers.js:140:23)
    at parseText (REDUCTED/dist/parseText.js:30:25)
    at REDUCTED/dist/parseFile.js:30:37
    at Generator.next (<anonymous>)
    at asyncGeneratorStep (REDUCTED/dist/parseFile.js:18:103)
    at _next (REDUCTED/dist/parseFile.js:20:194)
    at <anonymous>
```

This PR fixes this error.