### PR TITLE
Feature support rust and protocol buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,50 +39,52 @@ to extract your todos from comments.
 
 | Filetype      | Extension            | Notes                                      | Parser Name         |
 | ------------  | -------------------- | -------------------------------------------| ------------------- |
-| C#            | `.cs`                | Supports `// and /* */` comments.          | defaultParser       |
-| C++/C         | `.cpp` `.c` `.h`     | Supports `// and /* */` comments.          | defaultParser       |
-| Coffee-React  | `.cjsx`              | Supports `#` comments.                     | coffeeParser        |
-| Coffeescript  | `.coffee`            | Supports `#` comments.                     | coffeeParser        |
-| Crystal       | `.cr`                | Supports `#` comments.                     | coffeeParser        |
-| CSon          | `.cson`              | Supports `#` comments.                     | coffeeParser        |
-| CSS           | `.css`               | Supports `/* */` comments.                 | defaultParser       |
-| EJS           | `.ejs`               | Supports `<!-- -->` and `<%# %>`           | ejsParser           |
-| Erb           | `.erb`               | Supports `<!-- -->` and `<%# %>`           | ejsParser           |
-| Erlang        | `.erl` `.hrl`        | Supports `%` comments.                     | erlangParser        |
-| Go            | `.go`                | Supports `// and /* */` comments.          | defaultParser       |
-| Haml          | `.haml`              | Supports `/ -# <!-- --> and <%# %>`        | twigParser          |
-| Handlebars    | `.hbs` `.handlebars` | Supports `{{! }}` and `{{!-- --}}`         | hbsParser           |
-| Haskell       | `.hs`                | Supports `--`                              | haskellParser       |
-| Hogan         | `.hgn` `.hogan`      | Supports `{{! }}` and `{{!-- --}}`         | hbsParser           |
-| HTML          | `.html` `.htm`       | Supports `<!-- -->`                        | twigParser          |
-| Jade          | `.jade` `.pug`       | Supports `//` and `//-` comments.          | jadeParser          |
-| Java          | `.java`              | Supports `// and /* */` comments           | defaultParser        |
-| Javascript    | `.js` `.es` `.es6`   | Supports `// and /* */` comments           | defaultParser       |
-| Jsx           | `.jsx`               | Supports `// and /* */` comments.          | defaultParser       |
-| Kotlin        | `.kt`                | Supports `// and /* */` comments.          | defaultParser       |
-| Latex         | `.tex`               | Supports `\begin{comment}` and `%` comments| latexParser         |
-| Less          | `.less`              | Supports `// and /* */` comments.          | defaultParser       |
-| Markdown      | `.markdown`, `.md`   | Supports `<!-- -->`                        | twigParser           |
-| Mustache      | `.mustache`          | Supports `{{! }}` and `{{!-- --}}`         | hbsParser           |
-| Nunjucks      | `.njk`               | Supports `{#  #}` and `<!-- -->`           | twigParser          |
-| Objective-C   | `.m`                 | Supports `// and /* */` comments           | defaultParser       |
-| Objective-C++ | `.mm`                | Supports `// and /* */` comments           | defaultParser       |
-| Pascal        | `.pas`               | Supports `// and { }` comments.            | pascalParser        |
-| Perl          | `.pl`, `.pm`         | Supports `#` comments.                     | coffeeParser        |
-| PHP           | `.php`               | Supports `// and /* */` comments.          | defaultParser       |
-| Python        | `.py`                | Supports `"""` and `#` comments.           | pythonParser        |
-| Ruby          | `.rb`                | Supports `#` comments.                     | coffeeParser        |
-| Sass          | `.sass` `.scss`      | Supports `// and /* */` comments.          | defaultParser       |
-| Scala         | `.scala`             | Supports `// and /* */` comments.          | defaultParser       |
-| Shell         | `.sh` `.zsh` `.bash` | Supports `#` comments.                     | coffeeParser        |
-| SilverStripe  | `.ss`                | Supports `<%-- --%>` comments.             | ssParser            |
-| SQL           | `.sql`               | Supports `--` and `/* */` comments         | defaultParser & haskellParser |
-| Stylus        | `.styl`              | Supports `// and /* */` comments.          | defaultParser       |
-| Swift         | `.swift`             | Supports `// and /* */` comments.          | defaultParser       |
-| Twig          | `.twig`              | Supports `{#  #}` and `<!-- -->`           | twigParser          |
-| Typescript    | `.ts`, `.tsx`        | Supports `// and /* */` comments.          | defaultParser       |
-| Vue           | `.vue`               | Supports `//` `/* */` `<!-- -->` comments. | twigParser          |
-| Yaml          | `.yaml` `.yml`       | Supports `#` comments.                     | coffeeParser        |
+| C#              | `.cs`                | Supports `// and /* */` comments.          | defaultParser       |
+| C++/C           | `.cpp` `.c` `.h`     | Supports `// and /* */` comments.          | defaultParser       |
+| Coffee-React    | `.cjsx`              | Supports `#` comments.                     | coffeeParser        |
+| Coffeescript    | `.coffee`            | Supports `#` comments.                     | coffeeParser        |
+| Crystal         | `.cr`                | Supports `#` comments.                     | coffeeParser        |
+| CSon            | `.cson`              | Supports `#` comments.                     | coffeeParser        |
+| CSS             | `.css`               | Supports `/* */` comments.                 | defaultParser       |
+| EJS             | `.ejs`               | Supports `<!-- -->` and `<%# %>`           | ejsParser           |
+| Erb             | `.erb`               | Supports `<!-- -->` and `<%# %>`           | ejsParser           |
+| Erlang          | `.erl` `.hrl`        | Supports `%` comments.                     | erlangParser        |
+| Go              | `.go`                | Supports `// and /* */` comments.          | defaultParser       |
+| Haml            | `.haml`              | Supports `/ -# <!-- --> and <%# %>`        | twigParser          |
+| Handlebars      | `.hbs` `.handlebars` | Supports `{{! }}` and `{{!-- --}}`         | hbsParser           |
+| Haskell         | `.hs`                | Supports `--`                              | haskellParser       |
+| Hogan           | `.hgn` `.hogan`      | Supports `{{! }}` and `{{!-- --}}`         | hbsParser           |
+| HTML            | `.html` `.htm`       | Supports `<!-- -->`                        | twigParser          |
+| Jade            | `.jade` `.pug`       | Supports `//` and `//-` comments.          | jadeParser          |
+| Java            | `.java`              | Supports `// and /* */` comments           | defaultParser        |
+| Javascript      | `.js` `.es` `.es6`   | Supports `// and /* */` comments           | defaultParser       |
+| Jsx             | `.jsx`               | Supports `// and /* */` comments.          | defaultParser       |
+| Kotlin          | `.kt`                | Supports `// and /* */` comments.          | defaultParser       |
+| Latex           | `.tex`               | Supports `\begin{comment}` and `%` comments| latexParser         |
+| Less            | `.less`              | Supports `// and /* */` comments.          | defaultParser       |
+| Markdown        | `.markdown`, `.md`   | Supports `<!-- -->`                        | twigParser           |
+| Mustache        | `.mustache`          | Supports `{{! }}` and `{{!-- --}}`         | hbsParser           |
+| Nunjucks        | `.njk`               | Supports `{#  #}` and `<!-- -->`           | twigParser          |
+| Objective-C     | `.m`                 | Supports `// and /* */` comments           | defaultParser       |
+| Objective-C++   | `.mm`                | Supports `// and /* */` comments           | defaultParser       |
+| Pascal          | `.pas`               | Supports `// and { }` comments.            | pascalParser        |
+| Perl            | `.pl`, `.pm`         | Supports `#` comments.                     | coffeeParser        |
+| PHP             | `.php`               | Supports `// and /* */` comments.          | defaultParser       |
+| Protocol Buffer | `.proto`             | Supports `// and /* */` comments.          | defaultParser       |
+| Python          | `.py`                | Supports `"""` and `#` comments.           | pythonParser        |
+| Ruby            | `.rb`                | Supports `#` comments.                     | coffeeParser        |
+| Rust            | `.rs`                | Supports `// and /* */` comments.          | defaultParser       |
+| Sass            | `.sass` `.scss`      | Supports `// and /* */` comments.          | defaultParser       |
+| Scala           | `.scala`             | Supports `// and /* */` comments.          | defaultParser       |
+| Shell           | `.sh` `.zsh` `.bash` | Supports `#` comments.                     | coffeeParser        |
+| SilverStripe    | `.ss`                | Supports `<%-- --%>` comments.             | ssParser            |
+| SQL             | `.sql`               | Supports `--` and `/* */` comments         | defaultParser & haskellParser |
+| Stylus          | `.styl`              | Supports `// and /* */` comments.          | defaultParser       |
+| Swift           | `.swift`             | Supports `// and /* */` comments.          | defaultParser       |
+| Twig            | `.twig`              | Supports `{#  #}` and `<!-- -->`           | twigParser          |
+| Typescript      | `.ts`, `.tsx`        | Supports `// and /* */` comments.          | defaultParser       |
+| Vue             | `.vue`               | Supports `//` `/* */` `<!-- -->` comments. | twigParser          |
+| Yaml            | `.yaml` `.yml`       | Supports `#` comments.                     | coffeeParser        |
 
 Javascript is the default parser. **PRs for additional filetypes is most welcomed!!**
 

--- a/src/lib/parsers.ts
+++ b/src/lib/parsers.ts
@@ -47,6 +47,7 @@ const parsersDb: ExtensionsDb = {
     '.pug': { parserName: 'jadeParser' },
     '.py': { parserName: 'pythonParser' },
     '.rb': { parserName: 'coffeeParser' },
+    '.rs': { parserName: 'defaultParser' },
     '.sass': { parserName: 'defaultParser' },
     '.scala': { parserName: 'defaultParser' },
     '.scss': { parserName: 'defaultParser' },

--- a/src/lib/parsers.ts
+++ b/src/lib/parsers.ts
@@ -44,6 +44,7 @@ const parsersDb: ExtensionsDb = {
     '.php': { parserName: 'defaultParser', includedFiles: ['.html', '.js', '.css'] },
     '.pl': { parserName: 'coffeeParser' },
     '.pm': { parserName: 'coffeeParser' },
+    '.proto': { parserName: 'defaultParser' },
     '.pug': { parserName: 'jadeParser' },
     '.py': { parserName: 'pythonParser' },
     '.rb': { parserName: 'coffeeParser' },

--- a/tests/fixtures/protocol-buffer.proto
+++ b/tests/fixtures/protocol-buffer.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+/*
+ * FIXME: implement single line comment
+ *  This is a multiple-lines comment block
+ *  that spans over multiple
+ *  lines
+ */
+package example;
+
+service ChateService {
+    rpc Send(Message) returns (Empty);
+
+    // TODO: implements list method
+    //  rpc List (ChatFilter) returns (ChatList);
+}
+
+message Message {
+    string to = 1;
+    string content = 2;
+}
+
+message Empty {}
+

--- a/tests/fixtures/rust.rs
+++ b/tests/fixtures/rust.rs
@@ -1,0 +1,11 @@
+// TODO(main): This is a single-line comment
+
+fn main() {
+  /**
+   * FIXME: implement single line comment
+   * This is a multiple-lines comment block
+   * that spans over multiple
+   * lines
+   */
+  println!("Hello, world!"); /* TODO: supported? */
+}

--- a/tests/parser-spec.ts
+++ b/tests/parser-spec.ts
@@ -743,6 +743,25 @@ describe('parsing', function() {
         });
     });
 
+    describe('rust', function() {
+        it('handle rust lines comments', function() {
+            const file = getFixturePath('rust.rs');
+            const comments = getComments(file);
+            should.exist(comments);
+            comments.should.have.length(3);
+            verifyComment(comments[0], 'TODO', 1, 'This is a single-line comment');
+        });
+
+        it('handle rust block comments', function() {
+            const file = getFixturePath('rust.rs');
+            const comments = getComments(file);
+            should.exist(comments);
+            comments.should.have.length(3);
+            verifyComment(comments[1], 'FIXME', 5, 'implement single line comment');
+            verifyComment(comments[2], 'TODO', 10, 'supported?');
+        });
+    });
+
     describe('custom parsers', function() {
         it('returns custom parser todos', function() {
             const file = getFixturePath('file.unsupported');

--- a/tests/parser-spec.ts
+++ b/tests/parser-spec.ts
@@ -762,6 +762,24 @@ describe('parsing', function() {
         });
     });
 
+    describe('protocol-buffer', function() {
+        it('handle protocol-buffer lines comments', function() {
+            const file = getFixturePath('protocol-buffer.proto');
+            const comments = getComments(file);
+            should.exist(comments);
+            comments.should.have.length(2);
+            verifyComment(comments[1], 'TODO', 14, 'implements list method');
+        });
+
+        it('handle protocol-buffer block comments', function() {
+            const file = getFixturePath('protocol-buffer.proto');
+            const comments = getComments(file);
+            should.exist(comments);
+            comments.should.have.length(2);
+            verifyComment(comments[0], 'FIXME', 4, 'implement single line comment');
+        });
+    });
+
     describe('custom parsers', function() {
         it('returns custom parser todos', function() {
             const file = getFixturePath('file.unsupported');


### PR DESCRIPTION

## Add support for:

| Filetype      | Extension            | Notes                                      | Parser Name         |
| ------------  | -------------------- | -------------------------------------------| ------------------- |
| Protocol Buffer | `.proto`             | Supports `// and /* */` comments.          | defaultParser       |
| Rust            | `.rs`                | Supports `// and /* */` comments.          | defaultParser       |