### PR TITLE
feat: add link to todo's file+line in the markdown reporter

### DIFF
--- a/src/lib/reporters/markdown.ts
+++ b/src/lib/reporters/markdown.ts
@@ -6,7 +6,7 @@ const reporterConfig: ReporterConfig = {
         if (ref) {
             text = `@${ref} ${text}`;
         }
-        return [`| ${file} | ${line} | ${text}`];
+        return [`| [${file}](${file}#L${line}) | ${line} | ${text}`];
     },
     transformHeader(tag) {
         return [`### ${tag}s`, `| Filename | line # | ${tag}`, '|:------|:------:|:------'];


### PR DESCRIPTION
It is generates a markdown relative link so you can click on file name to jump to TODO file and line.