### PR TITLE
Resolved markdown lint findings for vscode and markdown reporters

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -49,6 +49,10 @@ const parseContentSync = (content: string, program: ProgramArgs, filename?: stri
 const outputTodos = (todos: TodoComment[], { reporter, exitNicely }: ProgramArgs) => {
     try {
         const output = report(todos, reporter);
+        // MD041/first-line-heading/first-line-h1
+        if (reporter == 'markdown' || reporter == 'vscode') {
+            console.log('# A list of TODOs and FIXMEs\n');
+        }
         console.log(output);
     } catch (e) {
         console.error(e);

--- a/src/lib/reporters/markdown.ts
+++ b/src/lib/reporters/markdown.ts
@@ -9,7 +9,7 @@ const reporterConfig: ReporterConfig = {
         return [`| [${file}](${file}#L${line}) | ${line} | ${text}`];
     },
     transformHeader(tag) {
-        return [`### ${tag}s`, `| Filename | line # | ${tag}`, '|:------|:------:|:------'];
+        return [`## ${tag}s\n`, `| Filename | line # | ${tag}`, '|:------|:------:|:------'];
     },
 };
 

--- a/src/lib/reporters/vscode.ts
+++ b/src/lib/reporters/vscode.ts
@@ -9,7 +9,7 @@ const reporterConfig: ReporterConfig = {
         return [`| [${file}](${file}#L${line}) | ${line} | ${text}`];
     },
     transformHeader(tag) {
-        return [`### ${tag}s`, `| Filename | line # | ${tag}`, '|:------|:------:|:------'];
+        return [`## ${tag}s\n`, `| Filename | line # | ${tag}`, '|:------|:------:|:------'];
     },
 };
 

--- a/tests/reporter-spec.ts
+++ b/tests/reporter-spec.ts
@@ -25,12 +25,14 @@ describe('reporting', function() {
             const report = getReport(file, BuiltinReporters.vscode, { extension: '.ts' });
             should.exist(report);
             report.should.eql([
-                '### TODOs',
+                '## TODOs',
+                '',
                 '| Filename | line # | TODO',
                 '|:------|:------:|:------',
                 '| [' + file + '](' + file + '#L1) | 1 | change to public',
                 '',
-                '### FIXMEs',
+                '## FIXMEs',
+                '',
                 '| Filename | line # | FIXME',
                 '|:------|:------:|:------',
                 '| [' + file + '](' + file + '#L11) | 11 | use jquery',
@@ -42,7 +44,8 @@ describe('reporting', function() {
             const report = getReport(file, BuiltinReporters.vscode, { extension: '.js' });
             should.exist(report);
             report.should.eql([
-                '### TODOs',
+                '## TODOs',
+                '',
                 '| Filename | line # | TODO',
                 '|:------|:------:|:------',
                 '| [' + file + '](' + file + '#L3) | 3 | @tregusti Use Symbol instead',
@@ -54,7 +57,8 @@ describe('reporting', function() {
             const report = getReport(file, BuiltinReporters.vscode, { extension: '.js' });
             should.exist(report);
             report.should.eql([
-                '### TODOs',
+                '## TODOs',
+                '',
                 '| Filename | line # | TODO',
                 '|:------|:------:|:------',
                 '| [' + file + '](' + file + '#L1) | 1 | ',


### PR DESCRIPTION
Hello! This change resolves markdown linter findings in the generated markdown and vscode reports:

- MD022/blanks-around-headings/blanks-around-headers: Headings should be surrounded by blank lines
- MD041/first-line-heading/first-line-h1: First line in file should be a top level heading

Sample report after changes:
![image](https://user-images.githubusercontent.com/21358910/72672256-0b9eb800-3a4f-11ea-969f-b425050f0480.png)

