### PR TITLE
Add support to cakephp ctp files

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ to extract your todos from comments.
 | Pascal          | `.pas`               | Supports `// and { }` comments.            | pascalParser        |
 | Perl            | `.pl`, `.pm`         | Supports `#` comments.                     | coffeeParser        |
 | PHP             | `.php`               | Supports `// and /* */` comments.          | defaultParser       |
+| CakePHP views   | `.ctp`               | Supports `// and /* */` comments.          | defaultParser       |
 | Protocol Buffer | `.proto`             | Supports `// and /* */` comments.          | defaultParser       |
 | Python          | `.py`                | Supports `"""` and `#` comments.           | pythonParser        |
 | Ruby            | `.rb`                | Supports `#` comments.                     | coffeeParser        |

--- a/src/lib/parsers.ts
+++ b/src/lib/parsers.ts
@@ -42,6 +42,7 @@ const parsersDb: ExtensionsDb = {
     '.njk': { parserName: 'twigParser' },
     '.pas': { parserName: 'pascalParser' },
     '.php': { parserName: 'defaultParser', includedFiles: ['.html', '.js', '.css'] },
+    '.ctp': { parserName: 'defaultParser', includedFiles: ['.html', '.js', '.css'] },
     '.pl': { parserName: 'coffeeParser' },
     '.pm': { parserName: 'coffeeParser' },
     '.proto': { parserName: 'defaultParser' },

--- a/tests/fixtures/sample.ctp
+++ b/tests/fixtures/sample.ctp
@@ -1,0 +1,16 @@
+<?php
+// TODO: This is a single-line comment
+
+# TODO: This is not yet implemented
+
+/*
+ * FIXME: implement single line comment
+ * This is a multiple-lines comment block
+ * that spans over multiple
+ * lines
+*/
+
+// You can also use comments to leave out parts of a code line
+$x = 5 /* TODO: supported? */ + 5;
+echo $x;
+?>

--- a/tests/parser-spec.ts
+++ b/tests/parser-spec.ts
@@ -557,6 +557,18 @@ describe('parsing', function() {
         });
     });
 
+    describe('ctp', function() {
+        it('handles standard js comments in ctp', function() {
+            const file = getFixturePath('sample.ctp');
+            const comments = getComments(file);
+            should.exist(comments);
+            comments.should.have.length(3);
+            verifyComment(comments[0], 'TODO', 2, 'This is a single-line comment');
+            verifyComment(comments[1], 'FIXME', 7, 'implement single line comment');
+            verifyComment(comments[2], 'TODO', 14, 'supported?');
+        });
+    });
+
     describe('swift', function() {
         it('handles standard comments in swift', function() {
             const file = getFixturePath('swift.swift');


### PR DESCRIPTION

Cakephp view files use the ctp file extension, but it's just a php file.