### PR TITLE
Add support for the Lua language

### DIFF
--- a/media/supported-languages.md
+++ b/media/supported-languages.md
@@ -1,5 +1,5 @@
-| Filetype      | Extension            | Notes                                      | Parser Name         |
-| ------------  | -------------------- | -------------------------------------------| ------------------- |
+| Filetype        | Extension            | Notes                                      | Parser Name         |
+| --------------  | -------------------- | -------------------------------------------| ------------------- |
 | C#              | `.cs`                | Supports `// and /* */` comments.          | defaultParser       |
 | C++/C           | `.cpp` `.c` `.h`     | Supports `// and /* */` comments.          | defaultParser       |
 | Coffee-React    | `.cjsx`              | Supports `#` comments.                     | coffeeParser        |
@@ -17,14 +17,15 @@
 | Hogan           | `.hgn` `.hogan`      | Supports `{{! }}` and `{{!-- --}}`         | hbsParser           |
 | HTML            | `.html` `.htm`       | Supports `<!-- -->`                        | twigParser          |
 | Jade            | `.jade` `.pug`       | Supports `//` and `//-` comments.          | jadeParser          |
-| Java            | `.java`              | Supports `// and /* */` comments           | defaultParser        |
+| Java            | `.java`              | Supports `// and /* */` comments           | defaultParser       |
 | Javascript      | `.js` `.es` `.es6`   | Supports `// and /* */` comments           | defaultParser       |
 | Julia           | `.jl`                | Supports `"""` and `#` comments.           | pythonParser        |
 | Jsx             | `.jsx`               | Supports `// and /* */` comments.          | defaultParser       |
 | Kotlin          | `.kt`                | Supports `// and /* */` comments.          | defaultParser       |
 | Latex           | `.tex`               | Supports `\begin{comment}` and `%` comments| latexParser         |
 | Less            | `.less`              | Supports `// and /* */` comments.          | defaultParser       |
-| Markdown        | `.markdown`, `.md`   | Supports `<!-- -->`                        | twigParser           |
+| Lua             | `.lua`               | Supports `--` and `--[[ ]]` comments.      | haskellParser       |
+| Markdown        | `.markdown`, `.md`   | Supports `<!-- -->`                        | twigParser          |
 | Mustache        | `.mustache`          | Supports `{{! }}` and `{{!-- --}}`         | hbsParser           |
 | Nunjucks        | `.njk`               | Supports `{#  #}` and `<!-- -->`           | twigParser          |
 | Objective-C     | `.m`                 | Supports `// and /* */` comments           | defaultParser       |
@@ -49,4 +50,3 @@
 | Typescript      | `.ts`, `.tsx`        | Supports `// and /* */` comments.          | defaultParser       |
 | Vue             | `.vue`               | Supports `//` `/* */` `<!-- -->` comments. | twigParser          |
 | Yaml            | `.yaml` `.yml`       | Supports `#` comments.                     | coffeeParser        |
-

--- a/src/lib/parsers.ts
+++ b/src/lib/parsers.ts
@@ -34,6 +34,7 @@ const parsersDb: ExtensionsDb = {
     '.jsx': { parserName: 'defaultParser' },
     '.kt': { parserName: 'defaultParser' },
     '.less': { parserName: 'defaultParser' },
+    '.lua': { parserName: 'haskellParser' },
     '.m': { parserName: 'defaultParser' },
     '.markdown': { parserName: 'twigParser' },
     '.md': { parserName: 'twigParser' },

--- a/tests/fixtures/lua.lua
+++ b/tests/fixtures/lua.lua
@@ -1,0 +1,15 @@
+function foo()
+    -- TODO: Support POST
+    -- TODO: Foobar print
+    print("foobar")
+    -- TODO: End function
+end
+
+function bar()
+--[[ Multiline
+comment
+block FIXME: maybe
+with a TODO: fix this
+]]
+    return
+end

--- a/tests/parser-spec.ts
+++ b/tests/parser-spec.ts
@@ -826,6 +826,27 @@ describe('parsing', function () {
         });
     });
 
+    describe('lua', function () {
+        it('parse -- comments', function () {
+            const file = getFixturePath('lua.lua');
+            const comments = getComments(file);
+            should.exist(comments);
+            comments.should.have.length(3);
+            verifyComment(comments[0], 'TODO', 2, 'Support POST');
+            verifyComment(comments[1], 'TODO', 3, 'Foobar print');
+            verifyComment(comments[2], 'TODO', 5, 'End function');
+        });
+
+        it('parse --[[ ]] comments', function () {
+            const file = getFixturePath('lua.lua');
+            const comments = getComments(file);
+            should.exist(comments);
+            comments.should.have.length(3);
+            verifyComment(comments[3], 'FIXME', 11, 'maybe');
+            verifyComment(comments[4], 'TODO', 12, 'fix this');
+        });
+    });
+
     describe('custom parsers', function () {
         it('returns custom parser todos', function () {
             const file = getFixturePath('file.unsupported');


### PR DESCRIPTION
Hey there, I tried adding support for Lua but I have one test failure I can't make sense of yet.

The multi line comments test fails with

```
  1) parsing
       lua
         parse --[[ ]] comments:
     TypeError: Cannot read property 'tag' of undefined
      at verifyComment (tests/parser-spec.ts:26:12)
      at Context.<anonymous> (tests/parser-spec.ts:845:13)
      at processImmediate (internal/timers.js:456:21)
```