### PR TITLE
closes #185 issue of missing characters at the end of table

### DIFF
--- a/src/lib/reporters/markdown.ts
+++ b/src/lib/reporters/markdown.ts
@@ -6,10 +6,10 @@ const reporterConfig: ReporterConfig = {
         if (ref) {
             text = `@${ref} ${text}`;
         }
-        return [`| [${file}](${file}#L${line}) | ${line} | ${text}`];
+        return [`| [${file}](${file}#L${line}) | ${line} | ${text} |`];
     },
     transformHeader(tag) {
-        return [`### ${tag}s`, `| Filename | line # | ${tag}`, '|:------|:------:|:------'];
+        return [`### ${tag}s`, `| Filename | line # | ${tag} |`, '|:------|:------:|:------|'];
     },
 };
 


### PR DESCRIPTION
Issue #185 points out the missing characters when generating the markdown table.
Here is a quick fix for the issue