### PR TITLE
Enable the Lua parser to extract TODOs from inline comments

### DIFF
--- a/src/lib/parsers/luaParser.ts
+++ b/src/lib/parsers/luaParser.ts
@@ -6,7 +6,7 @@ const multiLineCommentRegex = /--\[\[(?:[\s\S]*)]]/gim;
 
 const parserFactory: ParserFactory = ({ customTags }) => {
     const regex = getRegex(customTags);
-    const lineCommentRegex = new RegExp(`^\\s*--${regex}$`, 'mig');
+    const lineCommentRegex = new RegExp(`\\s*--${regex}$`, 'mig');
     const innerBlockRegex = new RegExp(`^\\s*${regex}\\s*$`, 'mig');
 
     return (contents, file) => {

--- a/tests/fixtures/lua.lua
+++ b/tests/fixtures/lua.lua
@@ -13,3 +13,9 @@ TODO: fix this
 ]]
     return
 end
+
+function inlineCommentsTest()-- TODO inline comment (space: no, colon: no)
+	local test = 123-- TODO: inline comment (space: no, colon: yes)
+	print(test) -- TODO inline comment (space: yes, colon: no)
+	return test -- TODO: inline comment (space: yes, colon: yes)
+end

--- a/tests/parser-spec.ts
+++ b/tests/parser-spec.ts
@@ -882,13 +882,17 @@ describe('parsing', function () {
             const file = getFixturePath('lua.lua');
             const comments = await getComments(file);
             should.exist(comments);
-            comments.should.have.length(5);
+            comments.should.have.length(9);
 
             verifyComment(comments[0], 'TODO', 2, 'Support POST');
             verifyComment(comments[1], 'FIXME', 3, 'Foobar print');
             verifyComment(comments[2], 'TODO', 5, 'End function');
             verifyComment(comments[3], 'FIXME', 11, 'maybe');
             verifyComment(comments[4], 'TODO', 12, 'fix this');
+            verifyComment(comments[5], 'TODO', 17, 'inline comment (space: no, colon: no)');
+            verifyComment(comments[6], 'TODO', 18, 'inline comment (space: no, colon: yes)');
+            verifyComment(comments[7], 'TODO', 19, 'inline comment (space: yes, colon: no)');
+            verifyComment(comments[8], 'TODO', 20, 'inline comment (space: yes, colon: yes)');
         });
     });
 


### PR DESCRIPTION
The regex pattern previously only matched comments that would take up an entire line.